### PR TITLE
Fixing python3 compatibility

### DIFF
--- a/php-fpm/agents/plugins/php_fpm_pools
+++ b/php-fpm/agents/plugins/php_fpm_pools
@@ -137,7 +137,9 @@ config_file=os.path.join(os.environ.get("MK_CONFDIR", "/etc/check_mk"), "php_fpm
 php_fpm = None
 
 if os.path.exists(config_file):
-    execfile(config_file)
+    with open(config_file, "rb") as source_file:
+        conf = compile(source_file.read(), config_file, "exec")
+    exec(conf)
 
 if not php_fpm:
     print("Config file does not exist or is empty!")

--- a/php-fpm/agents/plugins/php_fpm_pools
+++ b/php-fpm/agents/plugins/php_fpm_pools
@@ -28,7 +28,7 @@
 #
 # By default this plugin tries to detect all locally running php-fpm processes
 # and to monitor them. If this is not good for your environment you might
-# create an php-fpm.cfg file in MK_CONFDIR and populate the servers
+# create an php_fpm_pools.cfg file in MK_CONFDIR and populate the servers
 # list to prevent executing the detection mechanism.
 
 # sample configuration:


### PR DESCRIPTION
Hi,

The "execfile" function is no longer working on python3 so this fixes that.

Also I fixed the conf file name in the description section who recommanded to create php-fpm.cfg instead of php_fpm_pools.cfg.

Regards